### PR TITLE
Allow date parsing for older python versions with --auto

### DIFF
--- a/nvd_api_client.py
+++ b/nvd_api_client.py
@@ -304,7 +304,9 @@ def format_date(date_str: str) -> datetime:
         )
     except ValueError:
         try:
-            date = datetime.fromisoformat(date_str).replace(tzinfo=timezone.utc)
+            date = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%f").replace(
+                tzinfo=timezone.utc, microsecond=1
+            )
         except ValueError as exc:
             msg = f"not a valid date: {date_str}"
             raise argparse.ArgumentTypeError(msg) from exc


### PR DESCRIPTION
`fromisoformat` was added in Python 3.7.
With this PR, I intend to allow support for older versions by parsing the format manually. 

Dates in the JSON files are in the format `2023-11-06T16:31:59.113`